### PR TITLE
Fixed tailwind not purging in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "serve": "npm-run-all clean --parallel serve:*",
     "build:webpack": "webpack --mode production",
     "build:eleventy": "ELEVENTY_ENV=production eleventy",
-    "build": "run-s clean build:*"
+    "build": "NODE_ENV=production run-s clean build:*"
   },
   "keywords": [],
   "author": "",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,12 @@ module.exports = {
     // removeDeprecatedGapUtilities: true,
     // purgeLayersByDefault: true,
   },
-  purge: [],
+  purge: [
+    "./.eleventy.js",
+    "./src/_includes/**/*.njk",
+    "./src/pages/**/*.njk",
+    "./src/index.njk",
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
#### Fixed combining development version of tailwind css into `main.css` when running `npm run build`
Added missing file paths to `tailwind.config.js`.purge and changed build script to runs with `NODE_ENV=production`